### PR TITLE
civitai download

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The resource `type: download` can be seen as the last resort. Existing web downl
 - `rename_to` (optional)
 - `revision` (optional), if none is defined the latest version from the main branch is downloaded
 - `type` can either be `git`, `huggingface` or `download`
+- `api_key` (optional) for civitai
 </details>
 
 ## 🧞 Zoomaker Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zoomaker"
-version = "0.8.0"
+version = "0.8.1"
 description = "Zoomaker - Friendly house keeping for your AI model zoo and related resources."
 authors = ["Benedikt Groß"]
 readme = "README.md"


### PR DESCRIPTION
- fixed civitai download
- added automatic filename extraction from header
- added optional civitai api key (bearer) per download
- added option to run individual tests: eg `python .\tests.py test_install_civitai`